### PR TITLE
Add calling 'File.Close'

### DIFF
--- a/gen/writer.go
+++ b/gen/writer.go
@@ -15,6 +15,7 @@ func writeToFile(file, template string, structs structs) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	w := bufio.NewWriter(f)
 	defer w.Flush()


### PR DESCRIPTION
To ensure that the generated file is finally closed, I added calling 'File.Close'.