### PR TITLE
[FIX] Can't build when name of primary key isn't "Id".

### DIFF
--- a/gen/tpl_save.go
+++ b/gen/tpl_save.go
@@ -28,7 +28,7 @@ func (m *{{.Name}}) Save(validate ...bool) (bool, *ar.Errors) {
                         return false, errs
                 } else {
 			if lastId, err := result.LastInsertId(); err == nil {
-				m.Id = {{.PrimaryKeyType}}(lastId)
+				m.{{.PrimaryKeyField}} = {{.PrimaryKeyType}}(lastId)
 			}
 		}
                 return true, nil


### PR DESCRIPTION
Example:
----------


File `main.go`

```go
package main

//+AR
type User struct {
	ID   int `db:"pk"`
	Name string
}

func main() {
}
```

File `Makefile`

```makefile
all:
	argen main.go
	go build
```

### Before patch

```sh
$ make
argen main.go
go build
# _/tmp/ar
./main_gen.go:199: m.Id undefined (type *User has no field or method Id)
Makefile:2: recipe for target 'all' failed
make: *** [all] Error 2
```

### Patched

```sh
$ make
argen main.go
go build
```