### PR TITLE
gen: support the case that `field.Type` is `*ast.SelectorExpr`.

### DIFF
--- a/gen/parser.go
+++ b/gen/parser.go
@@ -101,9 +101,16 @@ func findStruct(specs []ast.Spec) (*structType, bool) {
 
 		st.Name = t.Name.Name
 		for _, f := range s.Fields.List {
+			var ident *ast.Ident
+			switch f.Type.(type) {
+			case *ast.Ident:
+				ident = f.Type.(*ast.Ident)
+			case *ast.SelectorExpr:
+				ident = f.Type.(*ast.SelectorExpr).Sel
+			}
 			field := field{
 				Name: f.Names[0].Name,
-				Type: f.Type.(*ast.Ident).Name,
+				Type: ident.Name,
 			}
 			if f.Tag != nil {
 				field.Tag = tag(f.Tag.Value)


### PR DESCRIPTION
I tried to add `time.Time` field in a struct like

```go
// main.go

//+AR
type User struct {
    Id      int `db:"pk"`
    Name    string
    Age     int
    Created time.Time
}
```

but `argen main.go` displayed the error below:

```
$ argen main.go
panic: interface conversion: ast.Expr is *ast.SelectorExpr, not *ast.Ident

goroutine 1 [running]:
github.com/monochromegane/argen/gen.findStruct(0x208708010, 0x1, 0x1, 0x263670, 0x3)
        /Users/a13462/golang/src/github.com/monochromegane/argen/gen/parser.go:104 +0x298
github.com/monochromegane/argen/gen.func·001(0x22084bc1f8, 0x2087061c0, 0x22084bc201)
        /Users/a13462/golang/src/github.com/monochromegane/argen/gen/parser.go:27 +0x11a
go/ast.inspector.Visit(0x20870a360, 0x22084bc1f8, 0x2087061c0, 0x0, 0x0)
        /usr/local/Cellar/go/1.4.2/libexec/src/go/ast/walk.go:374 +0x49
go/ast.Walk(0x22084bc1a0, 0x20870a360, 0x22084bc1f8, 0x2087061c0)
        /usr/local/Cellar/go/1.4.2/libexec/src/go/ast/walk.go:52 +0x59
go/ast.walkDeclList(0x22084bc1a0, 0x20870a360, 0x208706800, 0x3, 0x4)
        /usr/local/Cellar/go/1.4.2/libexec/src/go/ast/walk.go:38 +0xd4
go/ast.Walk(0x22084bc1a0, 0x20870a360, 0x22084bc170, 0x208510f80)
        /usr/local/Cellar/go/1.4.2/libexec/src/go/ast/walk.go:353 +0x2df1
go/ast.Inspect(0x22084bc170, 0x208510f80, 0x20870a360)
        /usr/local/Cellar/go/1.4.2/libexec/src/go/ast/walk.go:385 +0x63
github.com/monochromegane/argen/gen.AnotatedStructs(0x208510f80, 0x263670, 0x3, 0x0, 0x0, 0x0)
        /Users/a13462/golang/src/github.com/monochromegane/argen/gen/parser.go:37 +0x1f9
github.com/monochromegane/argen/gen.parse(0x7fff5fbff6de, 0x7, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/a13462/golang/src/github.com/monochromegane/argen/gen/gen.go:39 +0x151
github.com/monochromegane/argen/gen.Generate(0x7fff5fbff6de, 0x7, 0x3300f3, 0x0, 0x331294, 0x4, 0x0, 0x0)
        /Users/a13462/golang/src/github.com/monochromegane/argen/gen/gen.go:10 +0x53
main.main()
        /Users/a13462/golang/src/github.com/monochromegane/argen/cmd/argen/main.go:29 +0x126

goroutine 2 [runnable]:
runtime.forcegchelper()
        /usr/local/Cellar/go/1.4.2/libexec/src/runtime/proc.go:90
runtime.goexit()
        /usr/local/Cellar/go/1.4.2/libexec/src/runtime/asm_amd64.s:2232 +0x1

goroutine 3 [runnable]:
runtime.bgsweep()
        /usr/local/Cellar/go/1.4.2/libexec/src/runtime/mgc0.go:82
runtime.goexit()
        /usr/local/Cellar/go/1.4.2/libexec/src/runtime/asm_amd64.s:2232 +0x1

goroutine 4 [runnable]:
runtime.runfinq()
        /usr/local/Cellar/go/1.4.2/libexec/src/runtime/malloc.go:712
runtime.goexit()
        /usr/local/Cellar/go/1.4.2/libexec/src/runtime/asm_amd64.s:2232 +0x1
```

I fixed it in this PR to support the case that `field.Type` is `*ast.SelectorExpr`, and the following code

```go
// main.go
package main

import (
    "database/sql"
    "fmt"
    "time"

    _ "github.com/go-sql-driver/mysql"
)

//+AR
type User struct{
    Id int `db:"pk"`
    Name string
    Age int
    Created time.Time
}

func main() {
    db, err := sql.Open("mysql", "root:@/users?parseTime=true")
    if err != nil {
        panic(err)
    }
    defer db.Close()
    Use(db)

    r := User{Name: "john", Age: 20, Created: time.Now()}
    r.Save()
    f, err := User{}.First()
    if err != nil {
        panic(err)
    }
    fmt.Printf(f.Created.String())
}
```

works fine (the console output is like`2015-07-09 08:49:05 +0000 UTC`).