### PR TITLE
ar.Errors is implemented error interface.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -27,3 +27,15 @@ func (e *Errors) message() map[string][]error {
 	}
 	return e.Messages
 }
+
+func (e *Errors) Error() string {
+	resp := ""
+	msgs := e.message()
+	for key, errs := range msgs {
+		resp += key + ": "
+		for _, m := range errs {
+			resp += m.Error() + ". "
+		}
+	}
+	return resp
+}


### PR DESCRIPTION
Example code.
---------------

- `main.go`

```go
//go:generate argen
package main

import (
	"database/sql"
	"fmt"
	"os"

	_ "github.com/mattn/go-sqlite3"
)

//+AR
type User struct {
	Id   int `db:"pk"`
	Name string
}

func main() {
	db, err := sql.Open("sqlite3", ":memory:")
	if err != nil {
		panic(err)
	}
	Use(db)
	u := &User{}

	_, err = u.Save()
	if err != nil {
		fmt.Println("Error!!")
		fmt.Println(err)
		os.Exit(1)
	}
}
```

- `Makefile`

```makefile
all:
	go generate
	go build -o ar
```


Before patch
----------------

```sh
$ make
# => go generate
#    go build -o ar
#    # _/tmp/ara
#    ./main.go:26: cannot assign *ar.Errors to err (type error) in multiple assignment:
#    	*ar.Errors does not implement error (missing Error method)
#    Makefile:2: recipe for target 'all' failed
#    make: *** [all] Error 2
```

Patched
---------

```sh
$ make
# => go generate
#    go build -o ar
$ ./ar
# => Error!!
#    base: no such table: users. 
```