### PR TITLE
Change the ar.Errors to error interface

### DIFF
--- a/gen/tpl_create.go
+++ b/gen/tpl_create.go
@@ -3,7 +3,7 @@ package gen
 var create = &Template{
 	Name: "Create",
 	Text: `
-func (m {{.Name}}) Create(p {{.Name}}Params) (*{{.Name}}, *ar.Errors) {
+func (m {{.Name}}) Create(p {{.Name}}Params) (*{{.Name}}, error) {
 	n := m.Build(p)
         _, errs := n.Save()
         return n, errs

--- a/gen/tpl_delete.go
+++ b/gen/tpl_delete.go
@@ -3,7 +3,7 @@ package gen
 var delete = &Template{
 	Name: "Delete",
 	Text: `
-func (m *{{.Name}}) Delete() (bool, *ar.Errors) {
+func (m *{{.Name}}) Delete() (bool, error) {
         errs := &ar.Errors{}
         if _, err := ar.NewDelete(db, logger).Table("{{.TableName}}").Where("{{.PrimaryKeyColumn}}", m.{{.PrimaryKeyField}}).Exec(); err != nil {
                 errs.AddError("base", err)
@@ -12,7 +12,7 @@ func (m *{{.Name}}) Delete() (bool, *ar.Errors) {
         return true, nil
 }
 
-func (m {{.Name}}) DeleteAll() (bool, *ar.Errors) {
+func (m {{.Name}}) DeleteAll() (bool, error) {
         errs := &ar.Errors{}
         if _, err := ar.NewDelete(db, logger).Table("{{.TableName}}").Exec(); err != nil {
                 errs.AddError("base", err)

--- a/gen/tpl_destroy.go
+++ b/gen/tpl_destroy.go
@@ -3,7 +3,7 @@ package gen
 var destroy = &Template{
 	Name: "Destroy",
 	Text: `
-func (m *{{.Name}}) Destroy() (bool, *ar.Errors) {
+func (m *{{.Name}}) Destroy() (bool, error) {
 	return m.Delete()
 }
 `}

--- a/gen/tpl_save.go
+++ b/gen/tpl_save.go
@@ -11,7 +11,7 @@ func (m *{{.Name}}) IsPersistent() bool {
         return !m.IsNewRecord()
 }
 
-func (m *{{.Name}}) Save(validate ...bool) (bool, *ar.Errors) {
+func (m *{{.Name}}) Save(validate ...bool) (bool, error) {
 	if len(validate) == 0 || len(validate) > 0 && validate[0] {
 		if ok, errs := m.IsValid(); !ok {
 			return false, errs

--- a/gen/tpl_update.go
+++ b/gen/tpl_update.go
@@ -3,7 +3,7 @@ package gen
 var update = &Template{
 	Name: "Update",
 	Text: `
-func (m *{{.Name}}) Update(p {{.Name}}Params) (bool, *ar.Errors) {
+func (m *{{.Name}}) Update(p {{.Name}}Params) (bool, error) {
 {{range .Fields}}
 	if !ar.IsZero(p.{{.Name}}) {
                 m.{{.Name}} = p.{{.Name}}
@@ -11,7 +11,7 @@ func (m *{{.Name}}) Update(p {{.Name}}Params) (bool, *ar.Errors) {
 	return m.Save()
 }
 
-func (m *{{.Name}}) UpdateColumns(p {{.Name}}Params) (bool, *ar.Errors) {
+func (m *{{.Name}}) UpdateColumns(p {{.Name}}Params) (bool, error) {
 {{range .Fields}}
 	if !ar.IsZero(p.{{.Name}}) {
                 m.{{.Name}} = p.{{.Name}}

--- a/gen/tpl_validation.go
+++ b/gen/tpl_validation.go
@@ -3,7 +3,7 @@ package gen
 var validation = &Template{
 	Name: "Validation",
 	Text: `
-func (m {{.Name}}) IsValid() (bool, *ar.Errors) {
+func (m {{.Name}}) IsValid() (bool, error) {
         result := true
 	errors := &ar.Errors{}
 	var on ar.On


### PR DESCRIPTION
What about change in error because argen a function of the code that is output had returned the ar.Errors?
# Example code

``` go:main.go
//go:generate argen
package main

import (
    "database/sql"
    "fmt"
    "os"

    _ "github.com/mattn/go-sqlite3"
)

//+AR
type User struct {
    Id   int `db:"pk"`
    Name string
}

func main() {

    db, err := sql.Open("sqlite3", ":memory:")
    if err != nil {
        panic(err)
    }

    _, err = db.Exec("CREATE TABLE users(ID INTEGER PRIMARY KEY AUTOINCREMENT,NAME VARCHAR(255))")
    if err != nil {
        panic(err)
    }

    Use(db)
    u := &User{}

    _, err = u.Save()
    if err != nil {
        fmt.Println("Error!!")
        fmt.Println(err)
        os.Exit(1)
    }

    fmt.Println("Success!!")
}
```

``` bash
# argen main.go
# go run *.go
```
# Before patch

``` bash
# Error!!
# <nil>
# [Exit Status 1]
```

It is also an error in the part of the judgment without an error occurs in the Save().
"err" type of variable may change across ar.Error.
# Pached

```
# Success!!
```

This problem does not occur when the return value 'll be in error.

How about that?
